### PR TITLE
Add: flask_session module to default.nix (impure)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,16 @@ stdenv.mkDerivation rec {
   python36Packages.pip
   python36Packages.flask
   python36Packages.virtualenv
+  python36Packages.pip
   python36Packages.sqlalchemy
+  python36Packages.flask_sqlalchemy
   ];
+  shellHook = ''
+    export export FLASK_APP=application.py
+    FLASK_DEBUG=1
+    FLASK_ENV=development
+    virtualenv --no-setuptools venv
+    export PATH=$PWD/venv/bin:$PATH
+    pip install -r requirements.txt
+    '';
 }


### PR DESCRIPTION
This is slightly impure because it uses pip and virtualenv imperatively

This is ok for now: we can nixify these later. We're following the [manual](https://nixos.org/nixpkgs/manual/#how-to-consume-python-modules-using-pip-in-a-virtualenv-like-i-am-used-to-on-other-operating-systems)

Also note that this is broken. Running ```nix-shell`` will run into this [issue](https://github.com/NixOS/nixpkgs/issues/39558) .  (which has been [fixed](https://github.com/NixOS/nixpkgs/commit/7a7463d0a3fe6d39a7fc499a0fd9756a3c671e62) in develop)
